### PR TITLE
Smoother Error Handling

### DIFF
--- a/Frontend/src/lib/utils.ts
+++ b/Frontend/src/lib/utils.ts
@@ -6,11 +6,24 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+export const cleanErrorMessage = (message: string): string => {
+  let cleaned = message.replace(/^Error:\s*/, '');
+  cleaned = cleaned.split(/\s+at\s/)[0];
+  return cleaned.trim();
+};
+
+
 export const displayError = (message: string) => {
-  toast.error(message, {
-    position: "bottom-right",
+  const cleanedMessage = cleanErrorMessage(message);
+  toast.error(cleanedMessage, {
+    position: "top-right",
     autoClose: 3000,
-    hideProgressBar: false,
+    hideProgressBar: true,
+    closeOnClick: true,
+    pauseOnHover: true,
+    draggable: true,
+    progress: undefined,
+    className: "bg-red-600 text-white font-semibold",
   });
 };
 


### PR DESCRIPTION
Resolves #5 .

## Description

> The toasts were displaying the error message recieved from the backend directly, so message formatting and trimming is done. Also the design of the toasts are designed to be more user friendly.

## Live Demo (if any)
> 
<img width="956" alt="image" src="https://github.com/user-attachments/assets/947d616f-3687-4a91-a222-cef557641586" />


## Checkout
- [x] I have read all the contributor guidelines for the repo.
