### PR TITLE
fixed env config

### DIFF
--- a/Frontend/src/app/api.ts
+++ b/Frontend/src/app/api.ts
@@ -6,7 +6,7 @@ import { logoutSuccess, setAccessToken } from '../features/auth/AuthSlice';
 axios.defaults.withCredentials = true;
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_BACKEND_URL,
+  baseURL: import.meta.env.VITE_BACKEND_URL+'/api/v1',
   withCredentials: true, // This ensures cookies are sent with requests
 });
 


### PR DESCRIPTION
Resolves #15 .

## Description

fixed the misconfiguration in the .env file and moved the API prefix (/api/v1) to the frontend code. Now, we can simply set the backend URL as http://localhost:8000/.



## Checkout
- [ ] I have read all the contributor guidelines for the repo.
