### PR TITLE
removed dividing line when no mods present

### DIFF
--- a/Frontend/src/components/navigation/ManageMembersItem.tsx
+++ b/Frontend/src/components/navigation/ManageMembersItem.tsx
@@ -166,7 +166,7 @@ const ManageMembersItem = () => {
 
                 
                 {guests.length > 0 && (
-                    <CommandGroup heading="Guests" className="text-white">
+                    <CommandGroup heading="Members" className="text-white">
                         {guests.map((guest) => renderProfile(guest.profileId, "GUEST", guest._id))}
                     </CommandGroup>
                 )}

--- a/Frontend/src/components/navigation/ManageMembersItem.tsx
+++ b/Frontend/src/components/navigation/ManageMembersItem.tsx
@@ -155,28 +155,24 @@ const ManageMembersItem = () => {
 
                 {admin && ((moderators.length > 0 || guests.length > 0)) && (<CommandSeparator className="bg-white/20 my-2" />)}
                 
-                {/* If you want to not show 'moderator' text when no moderators are present, you can uncomment the code below and comment the one below the uncommented. */}
-                {/* {moderators.length > 0 && (
+                
+                {moderators.length > 0 && (
                     <CommandGroup heading="Moderators" className="text-white">
                         {moderators.map((moderator) => renderProfile(moderator.profileId, "MODERATOR", moderator._id))}
                     </CommandGroup>
-                )} */}
-                <CommandGroup heading="Moderators" className="text-white">
-                    {moderators.map((moderator) => renderProfile(moderator.profileId, "MODERATOR", moderator._id))}
-                </CommandGroup>
+                )}
+                
                 {moderators.length > 0 && guests.length > 0 && <CommandSeparator className="bg-white/20 my-2" />}
 
-                {/* If you want to not show 'guests' text when no guests are present, you can uncomment the code below and comment the one below the uncommented. */}
-                {/* {guests.length > 0 && (
+                
+                {guests.length > 0 && (
                     <CommandGroup heading="Guests" className="text-white">
                         {guests.map((guest) => renderProfile(guest.profileId, "GUEST", guest._id))}
                     </CommandGroup>
-                )} */}
+                )}
                 
                 
-                <CommandGroup heading="Guests" className="text-white">
-                    {guests.map((guest) => renderProfile(guest.profileId, "GUEST", guest._id))}
-                </CommandGroup>
+                
                 
             </CommandList>
         </Command>

--- a/Frontend/src/components/navigation/ManageMembersItem.tsx
+++ b/Frontend/src/components/navigation/ManageMembersItem.tsx
@@ -149,17 +149,35 @@ const ManageMembersItem = () => {
             />
             <CommandList className="border-none">
                 <CommandEmpty className="text-white">No results found.</CommandEmpty>
-                <CommandGroup heading="Admin" className="text-white">
+                <CommandGroup heading="Admin" className="text-white">  
                     {admin && renderProfile(admin.profileId, "ADMIN", admin._id)}
-                </CommandGroup>
-                <CommandSeparator className="bg-white/20 my-2" />
+                </CommandGroup>  
+
+                {admin && ((moderators.length > 0 || guests.length > 0)) && (<CommandSeparator className="bg-white/20 my-2" />)}
+                
+                {/* If you want to not show 'moderator' text when no moderators are present, you can uncomment the code below and comment the one below the uncommented. */}
+                {/* {moderators.length > 0 && (
+                    <CommandGroup heading="Moderators" className="text-white">
+                        {moderators.map((moderator) => renderProfile(moderator.profileId, "MODERATOR", moderator._id))}
+                    </CommandGroup>
+                )} */}
                 <CommandGroup heading="Moderators" className="text-white">
                     {moderators.map((moderator) => renderProfile(moderator.profileId, "MODERATOR", moderator._id))}
                 </CommandGroup>
-                <CommandSeparator className="bg-white/20 my-2" />
-                <CommandGroup heading="Members" className="text-white">
+                {moderators.length > 0 && guests.length > 0 && <CommandSeparator className="bg-white/20 my-2" />}
+
+                {/* If you want to not show 'guests' text when no guests are present, you can uncomment the code below and comment the one below the uncommented. */}
+                {/* {guests.length > 0 && (
+                    <CommandGroup heading="Guests" className="text-white">
+                        {guests.map((guest) => renderProfile(guest.profileId, "GUEST", guest._id))}
+                    </CommandGroup>
+                )} */}
+                
+                
+                <CommandGroup heading="Guests" className="text-white">
                     {guests.map((guest) => renderProfile(guest.profileId, "GUEST", guest._id))}
                 </CommandGroup>
+                
             </CommandList>
         </Command>
     );


### PR DESCRIPTION
Resolves #22 

## Description

Removed the dividing lines showing when no mods and guests are present

## Live Demo (if any)
![image](https://github.com/user-attachments/assets/59b3d515-918e-4b87-a86e-519beef86ec5)


## Checkout
- [ ] I have read all the contributor guidelines for the repo.
