### PR TITLE
added feature to create channel by moderator

### DIFF
--- a/Frontend/src/components/navigation/ServerChannels.tsx
+++ b/Frontend/src/components/navigation/ServerChannels.tsx
@@ -51,7 +51,7 @@ const ServerChannels = () => {
 
   return (
     <>
-      {currentUserRole === 'ADMIN' && (<CreateChannelModal />)}
+      {(currentUserRole === 'ADMIN' || currentUserRole === 'MODERATOR') && (<CreateChannelModal />)}
       <Command className="rounded-lg h-screen dark:bg-[#2B2D31] border-none text-white">
         <CommandInput placeholder="Search channel ..." />
         <CommandList>


### PR DESCRIPTION
Resolves #2

## Description
Extended the channel creation permissions by adding the moderator check. In the previous code create channel button was being conditionally rendered if User = Admin.


## Live Demo (if any)
![image](https://github.com/user-attachments/assets/a8b2ff68-f7b2-4b49-9fbd-d90733d417e5)
NO create channel option if user is guest
![image](https://github.com/user-attachments/assets/d1cb4d31-16fb-46b7-b0bf-e5465821b61a)


## Checkout
- [ ] I have read all the contributor guidelines for the repo.
