### PR TITLE
Implemented generate new invite link for servers

### DIFF
--- a/Backend/src/controllers/server.controller.ts
+++ b/Backend/src/controllers/server.controller.ts
@@ -70,6 +70,19 @@ const getServersWhereUserIsMember = asyncHandler(async (req: AuthRequest, res: R
     return res.status(200).json(new ApiResponse(200, servers, "Servers fetched successfully"));
 });
 
+const generateNewInviteCode = asyncHandler(async (req: AuthRequest, res: Response) => {
+    const { serverId } = req.body;
+    if (!serverId) {
+        throw new ApiError(400, "Cannot get server Id");
+    }
+    const newInviteCode = uuidv4();
+    const server = await Server.findByIdAndUpdate(serverId, { inviteCode: newInviteCode }, { new: true });
+    if (!server) {
+        throw new ApiError(404, "Server not found");
+    }
+    return res.status(200).json(new ApiResponse(200, server, "Invite code generated successfully"));
+})
+
 
 const createServer = asyncHandler(async (req: AuthRequest, res: Response) => {
     const { serverName, profileId } = req.body;
@@ -243,5 +256,6 @@ export {
     createServer,
     joinServer,
     leaveServer,
-    deleteServer
+    deleteServer,
+    generateNewInviteCode
 }

--- a/Backend/src/controllers/server.controller.ts
+++ b/Backend/src/controllers/server.controller.ts
@@ -73,16 +73,15 @@ const getServersWhereUserIsMember = asyncHandler(async (req: AuthRequest, res: R
 const generateNewInviteCode = asyncHandler(async (req: AuthRequest, res: Response) => {
     const { serverId } = req.body;
     if (!serverId) {
-        throw new ApiError(400, "Cannot get server Id");
+      throw new ApiError(400, "Cannot get server Id");
     }
     const newInviteCode = uuidv4();
     const server = await Server.findByIdAndUpdate(serverId, { inviteCode: newInviteCode }, { new: true });
     if (!server) {
-        throw new ApiError(404, "Server not found");
+      throw new ApiError(404, "Server not found");
     }
     return res.status(200).json(new ApiResponse(200, server, "Invite code generated successfully"));
-})
-
+  });
 
 const createServer = asyncHandler(async (req: AuthRequest, res: Response) => {
     const { serverName, profileId } = req.body;

--- a/Backend/src/routes/server.routes.ts
+++ b/Backend/src/routes/server.routes.ts
@@ -4,7 +4,8 @@ import {
     getServersWhereUserIsMember,
     joinServer,
     leaveServer,
-    deleteServer
+    deleteServer,
+    generateNewInviteCode
 } from '../controllers/server.controller.js'
 import { verifyJWT } from "../middleware/auth.middleware.js";
 import { upload } from "../middleware/multer.middleware.js";
@@ -29,5 +30,7 @@ router.route("/joinServer").post(verifyJWT, joinServer)
 router.route("/leaveServer").post(verifyJWT, leaveServer)
 
 router.route("/deleteServer").post(verifyJWT, deleteServer)
+
+router.route("/generateNewInviteCode").post(verifyJWT, generateNewInviteCode)
 
 export default router

--- a/Frontend/src/app/apiCalls.ts
+++ b/Frontend/src/app/apiCalls.ts
@@ -29,6 +29,16 @@ export const joinServer = async (inviteCode: string, profileId: string) => {
     }
 };
 
+export const generateNewInviteCode = async (serverId: string) => {
+    try {
+      const response = await api.post('/servers/generateNewInviteCode', { serverId });
+      return response.data.data;
+    } catch (error) {
+      console.error('Error regenerating invite link:', error);
+      throw error;
+    }
+  };
+
 export const getProfilesByServerId = async (serverId: string) => {
     try {
         const response = await api.post('/profiles/getProfilesByServerId', { serverId });

--- a/Frontend/src/components/modals/InvitePeopleModal.tsx
+++ b/Frontend/src/components/modals/InvitePeopleModal.tsx
@@ -10,24 +10,34 @@ import { Input } from '@/components/ui/input';
 import { Button } from "@/components/ui/button";
 import { Check, Copy, RefreshCw, UserPlus } from "lucide-react";
 import { useState } from "react";
+import { generateNewInviteCode } from '@/app/apiCalls';
 
 interface ServerModalProps {
     inviteCode: string;
+    serverId: string; // Ensure we pass serverId as a prop
 }
 
-const InvitePeopleModal = ({ inviteCode }: ServerModalProps) => {
+const InvitePeopleModal = ({ inviteCode, serverId }: ServerModalProps) => {
     const [copied, setCopied] = useState(false);
+    const [currentInvite, setCurrentInvite] = useState(inviteCode);
 
     const onCopy = () => {
-        navigator.clipboard.writeText(inviteCode);
+        navigator.clipboard.writeText(currentInvite);
         setCopied(true);
         setTimeout(() => {
             setCopied(false);
         }, 1000);
     };
 
-    const generateNewLink = () => {
-        console.log("New link generated");
+    // No parameter here; using serverId from props.
+    const handleGenerateNewLink = async () => {
+        try {
+            const newInviteResponse = await generateNewInviteCode(serverId);
+            // Assuming your API returns the new invite code directly, update the state.
+            setCurrentInvite(newInviteResponse.inviteCode);
+        } catch (error) {
+            console.error("Failed to regenerate invite code:", error);
+        }
     };
 
     return (
@@ -51,7 +61,7 @@ const InvitePeopleModal = ({ inviteCode }: ServerModalProps) => {
                     <div className='flex items-center mt-2 gap-x-2'>
                         <Input
                             className="bg-zinc-300/50 border-0 focus-visible:ring-0 text-white focus-visible:ring-offset-0"
-                            value={inviteCode}
+                            value={currentInvite}
                             readOnly={true}
                         />
                         <Button size="icon" onClick={onCopy}>
@@ -59,7 +69,7 @@ const InvitePeopleModal = ({ inviteCode }: ServerModalProps) => {
                         </Button>
                     </div>
                     <Button
-                        onClick={generateNewLink}
+                        onClick={handleGenerateNewLink}
                         variant="link"
                         size="sm"
                         className="text-xs text-white mt-4"

--- a/Frontend/src/components/navigation/Topbar.tsx
+++ b/Frontend/src/components/navigation/Topbar.tsx
@@ -46,7 +46,7 @@ const Topbar = () => {
       <ManageMembers isOpen={isOpen} onClose={toggleModal} />
 
       {isModerator && (
-        <InvitePeopleModal inviteCode={server.inviteCode}/>
+        <InvitePeopleModal inviteCode={server.inviteCode} serverId={server._id}/>
       )}
       {isAdmin && (
         <div className="mx-2">Server Settings</div>


### PR DESCRIPTION
Resolves #33 
## Description

Added the feature to regenerate the invite link for their server. This allows admins to refresh the invite code for security or organizational purposes.
Generating New invite code from uuidv4(Universally Unique Identifier), same as done for generating first-time server code.

## Live Demo 
https://github.com/user-attachments/assets/04ea5724-ef11-4313-a7d3-6c2b9d410ece



## Checkout
- [ ] I have read all the contributor guidelines for the repo.
